### PR TITLE
Added functionality to dynamically change applications

### DIFF
--- a/luis_sdk/index.js
+++ b/luis_sdk/index.js
@@ -48,7 +48,7 @@ var LUISResponse = require("./luis_response");
  * @1- appId a String containing the Application Id
  * @2- appKey a String containing the Subscription Key
  * @3- verbose a Boolean to choose whether to use the verbose version or not
- * @returns {{predict: predict, reply: reply}} an object containing the functions that need to be used
+ * @returns {{predict: predict, reply: reply, changeConfig: changeConfig}} an object containing the functions that need to be used
  */
 var LUISClient = function(initData) {
   validateInitData(initData);
@@ -100,6 +100,22 @@ var LUISClient = function(initData) {
         LUISOptions.path += util.format("&forceset=%s", forceSetParameterName);
       }
       httpHelper(LUISOptions, responseHandlers);
+    },
+    /**
+     * Changes the LUIS configuration for dynamic workspaces
+     * 
+     * @param newConfig an Object containing the new configuration
+     */
+    changeConfig: function(newConfig){
+      if(newConfig.hasOwnProperty("appId")){
+        appId = newConfig.appId;
+      }
+      if(newConfig.hasOwnProperty("appKey")){
+        appKey = newConfig.appKey;
+      }
+      if(newConfig.hasOwnProperty("verbose")){
+        verbose = newConfig.verbose;
+      }
     }
   };
 };


### PR DESCRIPTION
I added a function `changeConfig` so that users could easily change the luis's configuration if the application is using multiple luis's workspaces.

Sample usage:
```
var LUISclient = LUISClient({
  appId: APPID,
  appKey: APPKEY,
  verbose: true
});

var newConfig = {
  appId: newAPPID,
  appKey: newAPPKEY,
  verbose: false
};

LUISclient.changeConfig(newConfig);

```